### PR TITLE
Fixing a hang when starting Selenium

### DIFF
--- a/lib/selenium_rc/server.rb
+++ b/lib/selenium_rc/server.rb
@@ -91,6 +91,7 @@ module SeleniumRC
       timeout = 60
 
       until service_is_running?
+        sleep 0.1
         if timeout && (Time.now > (start_time + timeout))
           raise SocketError.new("Socket did not open within #{timeout} seconds")
         end


### PR DESCRIPTION
Hi,

This is Glenn Jahnke and Ken Mayer from Pivotal. We had a problem where Selenium would be looping, waiting to startup and it would never get past

"==> Waiting for Selenium RC server on port 60653... "

(would never report "Ready!" and browser would never start)

part of the startup. We believe it is due to allocating to many TCP Sockets too quickly, because you could see a socket that was half-open waiting. It was also challenging because it would never actually time out because it is probably hanging inside C code.

Our simple fix: add a 0.1 second sleep inside the loop. Worked like a charm.

Thanks,

Glenn & Ken
