### PR TITLE
Expose JAR location a a constant so other folks can use it

### DIFF
--- a/lib/selenium_rc.rb
+++ b/lib/selenium_rc.rb
@@ -2,3 +2,7 @@ dir = File.dirname(__FILE__)
 require "socket"
 require "#{dir}/selenium_rc/server"
 require "net/http"
+
+module SeleniumRC
+  SERVER_JAR_PATH = File.expand_path(File.join(File.dirname(__FILE__), '..', 'vendor', 'selenium-server.jar'))
+end

--- a/lib/selenium_rc/server.rb
+++ b/lib/selenium_rc/server.rb
@@ -29,7 +29,7 @@ module SeleniumRC
     end
 
     def start
-      command = "java -jar \"#{jar_path}\""
+      command = "java -jar \"#{SERVER_JAR_PATH}\""
       command << " -port #{port}"
       command << " #{args.join(' ')}" unless args.empty?
       log "Running: #{command}"
@@ -48,10 +48,6 @@ module SeleniumRC
       at_exit do
         stop
       end
-    end
-
-    def jar_path
-      File.expand_path("#{File.dirname(__FILE__)}/../../vendor/selenium-server.jar")
     end
 
     def wait


### PR DESCRIPTION
Hi,

I'm fixing up Webrat to use the JAR in selenium-rc instead of it's always-out-of-date-copy, and I don't want to have to have internal knowledge of selenium-rc or it's version number to access it, so can we expose it's location with a constant?

Thanks,

-Sam.
