### PR TITLE
Pull request for downgrade of selenium-server.jar

### DIFF
--- a/Thorfile
+++ b/Thorfile
@@ -3,7 +3,7 @@ require "zip/zip"
 class Joe < Thor
   desc "download", "download the Selenium jar file from Google Code repository"
   def download
-    url = "http://selenium.googlecode.com/files/selenium-server-standalone-2.20.0.jar"
+    url = "http://selenium.googlecode.com/files/selenium-server-standalone-2.16.0.jar"
     file = File.join("tmp", File.basename(url))
 
     FileUtils.mkdir_p("tmp")


### PR DESCRIPTION
After some messing around, I've noticed a very annoying bug with selenium-server 2.20. In some cases, well in many cases, at the end of the test run the shutdown server command does not work like you would expect.

In IE, it does not shutdown the browser (yes even much more often than currently), and in firefox it leaves a server jar zombie process.

This comes out looking bad when you have a CI build, and many builds, making the ci box run out of memory and crash.

I recommend downgrading to selenium-server 2.16 until the currently known issue with 2.20 is fixed.

Thanks.
